### PR TITLE
add phonegap debug parameter to app

### DIFF
--- a/api/src/main/java/com/github/chrisprice/phonegapbuild/api/data/apps/AppDetailsRequest.java
+++ b/api/src/main/java/com/github/chrisprice/phonegapbuild/api/data/apps/AppDetailsRequest.java
@@ -35,6 +35,7 @@ public class AppDetailsRequest {
   @JsonProperty("create_method")
   private String createMethod;
   private Keys keys;
+  private Boolean debug;
 
   public String getTitle() {
     return title;
@@ -74,6 +75,14 @@ public class AppDetailsRequest {
 
   public void setKeys(Keys keys) {
     this.keys = keys;
+  }
+
+  public Boolean getDebug() {
+    return debug;
+  }
+
+  public void setDebug(Boolean debug) {
+    this.debug = debug;
   }
 
 }

--- a/plugin/src/main/java/com/github/chrisprice/phonegapbuild/plugin/BuildMojo.java
+++ b/plugin/src/main/java/com/github/chrisprice/phonegapbuild/plugin/BuildMojo.java
@@ -215,6 +215,13 @@ public class BuildMojo extends AbstractPhoneGapBuildMojo {
       "android", "blackberry", "ios", "symbian", "webos", "winphone"};
 
   /**
+   * Enables debugging.
+   *
+   * @parameter default-value="false"
+   */
+   private boolean debug;
+
+  /**
    * @component role="com.github.chrisprice.phonegapbuild.plugin.utils.ResourceIdStore"
    */
   private ResourceIdStore<App> appIdStore;
@@ -391,6 +398,7 @@ public class BuildMojo extends AbstractPhoneGapBuildMojo {
       keys.setAndroid(androidKeyId.getId());
     }
     appDetailsRequest.setKeys(keys);
+    appDetailsRequest.setDebug(debug);
     return appDetailsRequest;
   }
 


### PR DESCRIPTION
Greetings,

This pull request adds debug support by using the "The PhoneGap Build Write API"
http://docs.build.phonegap.com/en_US/2.9.0/developer_api_write.md.html

When invoking the [Create a New App] we have an optional parameter "debug" that builds the app in debug mode.

To use the debug parameter configure the plugin with "&lt;debug&gt;true&lt;/debug&gt;".